### PR TITLE
Add cleanup tasks for removal of source and target VMs

### DIFF
--- a/roles/v2v.ci/defaults/main.yml
+++ b/roles/v2v.ci/defaults/main.yml
@@ -1,13 +1,16 @@
 ---
+v2v_ci_vmw_hostname: vcenter.example.com
+v2v_ci_vmw_user: administrator@vsphere.local
+v2v_ci_vmw_password: secret
 v2v_ci_miq_extra_providers:
   - name: V2V VMware
     type: ManageIQ::Providers::Vmware::InfraManager
-    hostname: vcenter.example.com
+    hostname: "{{ v2v_ci_vmw_hostname }}"
     zone:
       href: http://localhost:3000/api/zone/1
     credentials:
-      userid: administrator@vsphere.local
-      password: secret
+      userid: "{{ v2v_ci_vmw_user }}"
+      password: "{{ v2v_ci_vmw_password }}"
 v2v_ci_infra_mapping_name: "V2V_CI"
 v2v_ci_source_cluster: "V2V_vmware_cluster"
 v2v_ci_target_cluster: "V2V_ovirt_cluster"

--- a/roles/v2v.ci/tasks/main.yml
+++ b/roles/v2v.ci/tasks/main.yml
@@ -49,3 +49,10 @@
 - import_tasks: miq_monitor_transformations.yml
   tags:
     - miq_monitor_transformations
+
+- import_tasks: miq_post_cleanup.yml
+  when: miq_post_cleanup|default(false)|bool == true
+  delegate_to: localhost
+  connection: local
+  tags:
+    - miq_post_cleanup

--- a/roles/v2v.ci/tasks/miq_post_cleanup.yml
+++ b/roles/v2v.ci/tasks/miq_post_cleanup.yml
@@ -1,0 +1,24 @@
+---
+- name: Remove RHV/Ovirt target instances if present
+  ovirt_vms:
+    auth:
+      username: "{{ engine_user }}"
+      password: "{{ engine_password }}"
+      hostname: "{{ engine_fqdn }}"
+      insecure: yes
+    state: absent
+    name: "{{ item }}"
+    cluster: "{{ v2v_ci_target_cluster }}"
+  with_items: "{{ v2v_ci_migration_plan_vms }}"
+
+- name: Remove VMware source instances if present
+  vmware_guest:
+    hostname: "{{ v2v_ci_vmw_hostname }}"
+    username: "{{ v2v_ci_vmw_user }}"
+    password: "{{ v2v_ci_vmw_password }}"
+    validate_certs: no
+    state: absent
+    name: "{{ item }}"
+    cluster: "{{ v2v_ci_source_cluster }}"
+  with_items: "{{ v2v_ci_migration_plan_vms }}"
+  when: v2v_ci_remove_src_vms

--- a/roles/v2v.ci/vars/main.yml
+++ b/roles/v2v.ci/vars/main.yml
@@ -2,4 +2,9 @@
 # FIX ME: See https://github.com/ManageIQ/manageiq.org/issues/526 (checksums are not published publicly)
 v2v_ci_miq_image_checksum_url: http://file.cloudforms.lab.eng.rdu2.redhat.com/builds/manageiq/master/latest/SHA256SUM
 v2v_ci_miq_image_checksum_file: /tmp/SHA256SUM
+
+# Pre/Post deployment booleans:
+# v2v_ci_miq_vm_force_remove will remove existing MIQ/CFME VM if found
+# v2v_ci_vmw_remove_src_vms will remove existing source VMs from VMware if found
 v2v_ci_miq_vm_force_remove: false
+v2v_ci_remove_src_vms: false


### PR DESCRIPTION
- Tasks called via miq_post_cleanup tag
- It will only remove target VMs from Ovirt by default
- Removal of source VMs from vmware can be achieved by passing -e
  "v2v_ci_remove_src_vms=true"

Requires PyVmomi  for ansible VMware module : 
```
pip install PyVmomi
```
Sample runs with and without source VMs removal from vmware : 

```
ansible-playbook miq_run_step.yml -t miq_post_cleanup -e "@extra_vars.yml" -e "miq_post_cleanup=true"
ansible-playbook miq_run_step.yml -t miq_post_cleanup -e "@extra_vars.yml" -e "miq_post_cleanup=true" -e "v2v_ci_remove_src_vms=true"
```
